### PR TITLE
Ensure the Host header does not contain a query string

### DIFF
--- a/h1load.c
+++ b/h1load.c
@@ -2690,6 +2690,13 @@ int main(int argc, char **argv)
 
 	host = strdup(*argv);
 
+	// If URL is entered with a query string and without a path
+	// (such as http://192.0.2.1?s=1), host will be incorrectly
+	// sent as 192.0.2.1?s=1 which is not valid.
+       if ( !arg_url && strchr(host, '?')) {
+		die(1, "'?' found in host (%s). Did you forget the path in url?\n", host);
+       }
+
 	if (arg_url)
 		*arg_url = c;
 	else


### PR DESCRIPTION
If a user provides a URL without a path but with a query string (for example, http://192.0.2.1:8080?s=64) the query string is ignored, and the Host header is incorrectly set to 192.0.2.1:8080?s=64, which is invalid.

This behavior can lead to inaccurate benchmarking results.

This patch adds a check to ensure that when no explicit path is specified in the URL, the Host header does not include a query string (i.e., does not contain a ?). If such a case is detected, h1load will report an error.