### PR TITLE
fix exit code when stopped by -e, document exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,15 @@ requested connections will be allocatable. Please use "ulimit -n" to raise the
 value if needed. If not running as root, using "sudo prlimit -nXXX -p$$" can
 do the job on Linux.
 
+## Exit codes
+
+h1load uses the following exit codes:
+
+- **0**: normal exit — the test completed as expected (duration elapsed or
+  request quota reached)
+- **1**: fatal error before or during initialization — bad arguments, thread
+  creation failure, memory allocation error, SSL not compiled in, etc.
+- **2**: test interrupted by an error detected during the run — only possible
+  when using `-e` (stop on first error)
+
 

--- a/h1load.c
+++ b/h1load.c
@@ -2961,5 +2961,14 @@ int main(int argc, char **argv)
 	summary();
 	if (arg_pctl)
 		report_percentiles();
+
+	/* Exit codes:
+	 *   0: normal exit (test duration elapsed or request quota reached)
+	 *   1: fatal error before or during initialization (bad arguments,
+	 *      thread creation failure, memory allocation error, etc.)
+	 *   2: test interrupted by an error detected during the run (see -e)
+	 */
+	if (running & THR_STOP_ALL)
+		return 2;
 	return 0;
 }


### PR DESCRIPTION
When -e caused a test to stop on the first connection error, the program was exiting with code 0 instead of reporting a failure. Now exit code 2 is returned when THR_STOP_ALL is set at the end of the run, making it possible to distinguish:

- a normal completion (0),
- an initialization error (1),
- and a run-time error (2) in scripts.

The exit codes are also documented in the README and in a comment above the return statement.